### PR TITLE
Staffのテーブルを作成するマイグレーションについて、親となるCompanyとの外部キーを貼る形に修正

### DIFF
--- a/laravel/app/Models/Staff.php
+++ b/laravel/app/Models/Staff.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property-read \App\Models\Company|null $company
+ * @property-read \App\Models\Company $company
  * @method static \Database\Factories\StaffFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|Staff newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Staff newQuery()

--- a/laravel/database/migrations/2023_12_12_133535_create_staffs_table.php
+++ b/laravel/database/migrations/2023_12_12_133535_create_staffs_table.php
@@ -15,10 +15,10 @@ return new class () extends Migration {
             $table->bigIncrements('id')->comment('スタッフID');
 
             // ↓not foreign key. just a relation column.
-            $table->bigInteger('company_id')->comment('会社ID');
+            // $table->bigInteger('company_id')->comment('会社ID');
 
             // ↓foreign key.
-            // $table->foreignId('company_id')->comment('会社ID')->constrained('companies')->onDelete('cascade');
+            $table->foreignId('company_id')->comment('会社ID')->constrained('companies')->onDelete('cascade');
 
             $table->string('col1')->comment('カラム1');
             $table->string('col2')->nullable()->comment('カラム2');


### PR DESCRIPTION
- laravel-ide-helperを実行すると以下の差異が発生する
  - StaffのCompanyを参照するproperty-readアノテーションが「Company|null → Company」となる（ここまではOK）
  - AchievementのCompanyを参照するproperty-readアノテーションは「Company|null」のままとなっている
    - 実際にはAchievementはCompanyに従属するデータを扱うテーブルになるためcompany_idがnullになりうることはなく「@property-read \App\Models\Company $company」となってほしい