### PR TITLE
Achievementのテーブルを作成するマイグレーションについて、親となるCompanyとの外部キーを貼る形に修正（ただし、larave…

### DIFF
--- a/laravel/app/Models/Staff.php
+++ b/laravel/app/Models/Staff.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property-read \App\Models\Company|null $company
+ * @property-read \App\Models\Company $company
  * @method static \Database\Factories\StaffFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|Staff newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Staff newQuery()

--- a/laravel/config/ide-helper.php
+++ b/laravel/config/ide-helper.php
@@ -159,7 +159,7 @@ return [
     'ignored_models' => [
         // User::class,
         // Company::class,
-        // Achievement::class,
+        Achievement::class,
         // Staff::class
     ],
 

--- a/laravel/database/migrations/2023_12_12_133541_create_achievements_table.php
+++ b/laravel/database/migrations/2023_12_12_133541_create_achievements_table.php
@@ -15,10 +15,10 @@ return new class () extends Migration {
             $table->bigIncrements('id')->comment('実績ID');
 
             // ↓not foreign key. just a relation column.
-            $table->bigInteger('company_id')->comment('会社ID');
+            // $table->bigInteger('company_id')->comment('会社ID');
 
             // ↓foreign key.
-            // $table->foreignId('company_id')->comment('会社ID')->constrained('companies')->onDelete('cascade');
+            $table->foreignId('company_id')->comment('会社ID')->constrained('companies')->onDelete('cascade');
 
             $table->string('col1')->comment('カラム1');
             $table->string('col2')->nullable()->comment('カラム2');


### PR DESCRIPTION
…l-ide-helperの設定ファイル（ide-helper.php）を使用してAchievementについてPHPDocの補完の対象外とする設定を実施）

- laravel-ide-helperを実行すると以下の差異が発生する
  - AchievementのCompanyを参照するproperty-readアノテーションは「Company|null」のまま（これは除外設定しているため当然）
  - StaffのCompanyを参照するproperty-readアノテーションが「Company|null → Company」となる（？？）
    - laralvel-ide-helperのModelCommandの中で先に処理したモデルについて補完の対象/非対象に関わらず何らかのキャッシュのようなことをしているのかも？